### PR TITLE
fix(stft_loss): mask frequency axis (not frames) for high-band loss

### DIFF
--- a/stft_loss.py
+++ b/stft_loss.py
@@ -115,9 +115,9 @@ class STFTLoss(torch.nn.Module):
         y_mag = stft(y, self.fft_size, self.shift_size, self.win_length, self.window)
 
         if self.band == "high":
-            freq_mask_ind = x_mag.shape[1] // 2  # only select high frequency bands
-            sc_loss  = self.spectral_convergence_loss(x_mag[:,freq_mask_ind:,:], y_mag[:,freq_mask_ind:,:])
-            mag_loss = self.log_stft_magnitude_loss(x_mag[:,freq_mask_ind:,:], y_mag[:,freq_mask_ind:,:])
+            freq_mask_ind = x_mag.shape[-1] // 2  # only select high frequency bands
+            sc_loss  = self.spectral_convergence_loss(x_mag[...,freq_mask_ind:], y_mag[...,freq_mask_ind:])
+            mag_loss = self.log_stft_magnitude_loss(x_mag[...,freq_mask_ind:], y_mag[...,freq_mask_ind:])
         elif self.band == "full":
             sc_loss  = self.spectral_convergence_loss(x_mag, y_mag)
             mag_loss = self.log_stft_magnitude_loss(x_mag, y_mag) 

--- a/tests/test_stft_high_band.py
+++ b/tests/test_stft_high_band.py
@@ -1,0 +1,59 @@
+"""Regression test for the high-band STFT loss axis bug.
+
+With ``band="high"``, ``STFTLoss.forward()`` must compute the losses on the
+upper half of the frequency bins only. Before the fix it sliced axis 1
+(time frames) instead of the frequency axis, so the high-band loss was
+computed over low frequencies and half the utterance.
+
+Run with CPU torch:
+    uv run --python 3.11 --with torch --with pytest \
+        --index-url https://download.pytorch.org/whl/cpu \
+        pytest tests/test_stft_high_band.py
+"""
+import os
+import sys
+
+import torch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from stft_loss import STFTLoss  # noqa: E402
+
+
+class ShapeRecorder(torch.nn.Module):
+    """Replacement sub-loss that records the shapes it receives."""
+
+    def __init__(self):
+        super().__init__()
+        self.shapes = []
+
+    def forward(self, x_mag, y_mag):
+        self.shapes.append((tuple(x_mag.shape), tuple(y_mag.shape)))
+        return torch.tensor(0.0)
+
+
+def test_high_band_masks_frequency_axis_not_frames():
+    fft_size = 64
+    loss = STFTLoss(fft_size=fft_size, shift_size=16, win_length=32,
+                    band="high")
+    loss.spectral_convergence_loss = ShapeRecorder()
+    loss.log_stft_magnitude_loss = ShapeRecorder()
+
+    x = torch.randn(2, 1000)
+    y = torch.randn(2, 1000)
+    loss(x, y)
+
+    n_frames = 1 + 1000 // 16  # 63 frames (center-padded STFT)
+    n_bins = fft_size // 2 + 1              # 33 frequency bins
+    high_bins = n_bins - n_bins // 2        # upper half: 17 bins
+
+    for recorder in (loss.spectral_convergence_loss,
+                     loss.log_stft_magnitude_loss):
+        assert len(recorder.shapes) == 1
+        x_shape, y_shape = recorder.shapes[0]
+        assert x_shape == y_shape
+        # Frames must be intact; only the frequency axis is halved.
+        assert x_shape == (2, n_frames, high_bins), (
+            f"expected (batch, {n_frames} frames, {high_bins} high-freq "
+            f"bins), got {x_shape} — high-band mask hit the wrong axis"
+        )


### PR DESCRIPTION
## Summary

With `band="high"` (used by `configs/DNS-large-high.json`), `STFTLoss.forward()` is meant to compute the spectral-convergence and log-magnitude losses on the upper half of the frequency bins only ("only select high frequency bands"). Instead it drops the second half of the time frames and keeps all frequencies, so the high-band loss is computed over low frequencies and half the utterance.

## Root cause

`stft()` returns the magnitude spectrogram as `(B, #frames, fft_size // 2 + 1)` (per its docstring: real/imag `(B, freq, frames)` are transposed with `.transpose(2, 1)`). The high-band code used axis 1 (frames) for the frequency mask:

```python
freq_mask_ind = x_mag.shape[1] // 2  # only select high frequency bands
sc_loss  = self.spectral_convergence_loss(x_mag[:,freq_mask_ind:,:], y_mag[:,freq_mask_ind:,:])
mag_loss = self.log_stft_magnitude_loss(x_mag[:,freq_mask_ind:,:], y_mag[:,freq_mask_ind:,:])
```

## Fix

Mask the last axis (frequency bins):

```python
freq_mask_ind = x_mag.shape[-1] // 2
... x_mag[...,freq_mask_ind:] ...
```

## Testing

No test suite exists in the repo. Verified with a standalone script that records the tensor shapes seen by both sub-losses for a `band="high"` `STFTLoss(fft_size=64)` on random signals (full magnitude shape `(2, 63 frames, 33 bins)`):

- With the fix: losses receive `(2, 63, 17)` — frames intact, upper half of the 33 frequency bins selected (PASS).
- With the fix stashed (unmodified code): losses receive `(2, 32, 33)` — frames wrongly halved, all frequencies kept (AssertionError).

Command: `uv run --python 3.11 --with torch --index-url https://download.pytorch.org/whl/cpu python test_high_band.py` (CPU torch, no GPU needed).

## Why existing tests missed it

The repo has no tests, and the bug is silent: the loss still computes a finite scalar, just over the wrong axes.