### PR TITLE
fix: bare except in checkpoint loader swallows KeyboardInterrupt

### DIFF
--- a/tests/test_no_bare_except.py
+++ b/tests/test_no_bare_except.py
@@ -1,0 +1,17 @@
+import ast
+import os
+import unittest
+
+
+class TestNoBareExcept(unittest.TestCase):
+    def test_train_py_has_no_bare_except(self):
+        path = os.path.join(os.path.dirname(__file__), '..', 'train.py')
+        with open(path) as f:
+            tree = ast.parse(f.read())
+        bare_handlers = [
+            node.lineno
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ExceptHandler) and node.type is None
+        ]
+        self.assertEqual(bare_handlers, [], "train.py contains bare except: handlers")
+

--- a/train.py
+++ b/train.py
@@ -115,7 +115,7 @@ def train(num_gpus, rank, group_name,
             time0 -= checkpoint['training_time_seconds']
             print('Model at iteration %s has been trained for %s seconds' % (ckpt_iter, checkpoint['training_time_seconds']))
             print('checkpoint model loaded successfully')
-        except:
+        except Exception:
             ckpt_iter = -1
             print('No valid checkpoint model found, start training from initialization.')
     else:


### PR DESCRIPTION
This PR addresses the following issue in `train.py`: bare except in checkpoint loader swallows KeyboardInterrupt.

## Changes
- `train.py`: bare except in checkpoint loader swallows KeyboardInterrupt.

## Details
```diff
--- a/train.py
+++ b/train.py
@@ -1,1 +1,1 @@
-        except:
+        except Exception:
```

## Tests
- `tests/test_no_bare_except.py`

```diff
--- /dev/null
+++ b/tests/test_no_bare_except.py
@@ -0,0 +1,17 @@
+import ast
+import os
+import unittest
+
+
+class TestNoBareExcept(unittest.TestCase):
+    def test_train_py_has_no_bare_except(self):
+        path = os.path.join(os.path.dirname(__file__), '..', 'train.py')
+        with open(path) as f:
+            tree = ast.parse(f.read())
+        bare_handlers = [
+            node.lineno
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ExceptHandler) and node.type is None
+        ]
+        self.assertEqual(bare_handlers, [], "train.py contains bare except: handlers")
+
+
+if __name__ == '__main__':
+    unittest.main()
```