### PR TITLE
fix: bare except clause swallows KeyboardInterrupt and SystemExit

### DIFF
--- a/tests/test_train_bare_except.py
+++ b/tests/test_train_bare_except.py
@@ -1,0 +1,15 @@
+import ast
+from pathlib import Path
+
+TRAIN_PY = Path(__file__).resolve().parent.parent / 'train.py'
+
+
+def test_no_bare_except_in_train_py():
+    tree = ast.parse(TRAIN_PY.read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Try):
+            for handler in node.handlers:
+                if handler.type is None:
+                    raise AssertionError(
+                        "Found bare except clause in train.py"
+                    )

--- a/train.py
+++ b/train.py
@@ -115,7 +115,7 @@ def train(num_gpus, rank, group_name,
             time0 -= checkpoint['training_time_seconds']
             print('Model at iteration %s has been trained for %s seconds' % (ckpt_iter, checkpoint['training_time_seconds']))
             print('checkpoint model loaded successfully')
-        except:
+        except Exception:
             ckpt_iter = -1
             print('No valid checkpoint model found, start training from initialization.')
     else:


### PR DESCRIPTION
This PR addresses the following issue in `train.py`: bare except clause swallows KeyboardInterrupt and SystemExit.

## Changes
- `train.py`: bare except clause swallows KeyboardInterrupt and SystemExit.

## Details
See the Files changed tab for the exact diff.

## Tests
- `tests/test_train_bare_except.py`