### PR TITLE
fix: random seed calls run at import time instead of script entry

### DIFF
--- a/tests/test_train_seed_guard.py
+++ b/tests/test_train_seed_guard.py
@@ -1,0 +1,22 @@
+import ast
+from pathlib import Path
+
+TRAIN_PY = Path(__file__).resolve().parent.parent / 'train.py'
+
+
+def test_seed_calls_not_at_module_level():
+    tree = ast.parse(TRAIN_PY.read_text())
+    for stmt in tree.body:
+        if not isinstance(stmt, ast.Expr):
+            continue
+        call = stmt.value
+        if not isinstance(call, ast.Call):
+            continue
+        name = None
+        if isinstance(call.func, ast.Attribute):
+            name = call.func.attr
+        elif isinstance(call.func, ast.Name):
+            name = call.func.id
+        assert name not in ('seed', 'manual_seed'), (
+            f"Seed call {name} found at module level"
+        )

--- a/train.py
+++ b/train.py
@@ -38,10 +38,6 @@ import torch.nn as nn
 from torch.utils.tensorboard import SummaryWriter
 
 import random
-random.seed(0)
-torch.manual_seed(0)
-np.random.seed(0)
-
 
 from distributed import init_distributed, apply_gradient_allreduce, reduce_tensor
 
@@ -231,4 +227,7 @@ if __name__ == "__main__":
 
     torch.backends.cudnn.enabled = True
     torch.backends.cudnn.benchmark = True
+    random.seed(0)
+    torch.manual_seed(0)
+    np.random.seed(0)
     train(num_gpus, args.rank, args.group_name, **train_config)


### PR DESCRIPTION
This PR fixes a script issue in `train.py`: random seed calls run at import time instead of script entry.

## Changes
- `train.py`: random seed calls run at import time instead of script entry.

## Details
See the Files changed tab for the exact diff.

## Tests
- `tests/test_train_seed_guard.py`